### PR TITLE
workaround: mkdir automatically

### DIFF
--- a/cica_generator.sh
+++ b/cica_generator.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-rm -rf ./tmp/* # :p
+rm -rf ./tmp # :p
+rm -rf ./Cica
+mkdir tmp
+mkdir Cica
 #
 # Cica Generator
 cica_version="1.0"


### PR DESCRIPTION
`git clone` したままだとディレクトリがなくて合成スクリプトが中断してしまうので、ディレクトリを自動生成するようにしました。