### PR TITLE
ignoring_center に含まれる各文字の幅がわずかに小さい

### DIFF
--- a/cica.py
+++ b/cica.py
@@ -558,6 +558,7 @@ def build_font(_f):
         g.transform((0.91,0,0,0.91,0,0))
         if _f.get('italic'):
             g.transform(psMat.skew(0.25))
+            g.width = g.width + g.font.ascent * 0.25
         if g.width > 700:
             width = 1024
         else:

--- a/cica.py
+++ b/cica.py
@@ -558,6 +558,12 @@ def build_font(_f):
         g.transform((0.91,0,0,0.91,0,0))
         if _f.get('italic'):
             g.transform(psMat.skew(0.25))
+        if g.width > 700:
+            width = 1024
+        else:
+            width = 512
+        g.transform(psMat.translate((width - g.width)/2, 0))
+        g.width = width
         if g.encoding in ignoring_center:
             pass
         else:

--- a/cica.py
+++ b/cica.py
@@ -191,7 +191,7 @@ def set_os2_values(_font, _info):
     _font.hhea_descent = 100
     _font.hhea_descent_add = True
     _font.hhea_linegap = 0
-    _font.os2_panose = (2, 11, weight / 100, 9, 2, 2, 3, 2, 2, 7)
+    _font.os2_panose = (2, 11, int(weight / 100), 9, 2, 2, 3, 2, 2, 7)
     return _font
 
 def align_to_center(_g):

--- a/cica.py
+++ b/cica.py
@@ -556,10 +556,13 @@ def build_font(_f):
     ]
     for g in cica.glyphs():
         g.transform((0.91,0,0,0.91,0,0))
+        full_half_threshold = 700
         if _f.get('italic'):
             g.transform(psMat.skew(0.25))
-            g.width = g.width + g.font.ascent * 0.25
-        if g.width > 700:
+            skew_amount = g.font.ascent * 0.91 * 0.25
+            g.width = g.width + skew_amount
+            full_half_threshold += skew_amount
+        if g.width > full_half_threshold:
             width = 1024
         else:
             width = 512


### PR DESCRIPTION
手元の環境

* openSUSE Leap 15.0 (非 HiDPI)
* fonts.conf (fontconfig) で autohint と hinting を false に
* Emacs 25.3.1

で表示すると、下図のように句読点やかぎ括弧などの記号の幅が少し狭くなっていてうまく揃いません。
![Cica-3.0.0](https://user-images.githubusercontent.com/1675738/41503732-3ab3428a-7216-11e8-88eb-0598b063a0f7.png)

[`align_to_center`](https://github.com/miiton/Cica/blob/c128e210934a440c3d8471b693332d747f64d40b/cica.py#L197) 関数で行われているように幅を設定して、 これをちゃんと揃うように調整してみました。
![fixed](https://user-images.githubusercontent.com/1675738/41504213-2c253108-7223-11e8-9cb3-d7bbba962aaa.png)

ついでに斜体の場合の位置も少し調整しています。
