### PR TITLE
fetch fonts on docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,35 @@
 FROM ubuntu:18.04
 MAINTAINER miiton <468745+miiton@users.noreply.github.com>
 
+ENV HACK_VERSION v3.003
+ENV MGENPLUS_VERSION 20150602
+ENV NOTO_EMOJI_VERSION master
+ENV DEJAVU_VERSION 2.37
+ENV ICONSFORDEVS_VERSION master
+
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    software-properties-common fontforge unar git curl
+    software-properties-common fontforge unar git curl && \
+    mkdir /work
+WORKDIR /work
+COPY sourceFonts sourceFonts
+RUN curl -L https://github.com/source-foundry/Hack/releases/download/$HACK_VERSION/Hack-$HACK_VERSION-ttf.zip -o /tmp/hack.zip && \
+    unar /tmp/hack.zip -o /tmp/hack && cp /tmp/hack/ttf/* sourceFonts/ && \
+    curl -L https://osdn.jp/downloads/users/8/8598/rounded-mgenplus-$MGENPLUS_VERSION.7z -o /tmp/rounded-mgenplus.7z && \
+    unar /tmp/rounded-mgenplus.7z -o /tmp && \
+    cp /tmp/rounded-mgenplus/rounded-mgenplus-1m-regular.ttf sourceFonts/ && \
+    cp /tmp/rounded-mgenplus/rounded-mgenplus-1m-bold.ttf sourceFonts/ && \
+    curl -L https://github.com/googlei18n/noto-emoji/raw/$NOTO_EMOJI_VERSION/fonts/NotoEmoji-Regular.ttf -o sourceFonts/NotoEmoji-Regular.ttf && \
+    curl -L http://sourceforge.net/projects/dejavu/files/dejavu/$DEJAVU_VERSION/dejavu-fonts-ttf-$DEJAVU_VERSION.zip -o /tmp/dejavu.zip && \
+    unar /tmp/dejavu.zip -o /tmp && \
+    cp /tmp/dejavu-fonts-ttf-$DEJAVU_VERSION/ttf/DejaVuSansMono.ttf sourceFonts/ && \
+    cp /tmp/dejavu-fonts-ttf-$DEJAVU_VERSION/ttf/DejaVuSansMono-Bold.ttf sourceFonts/ && \
+    curl -L https://github.com/mirmat/iconsfordevs/raw/$ICONSFORDEVS_VERSION/fonts/iconsfordevs.ttf -o sourceFonts/iconsfordevs.ttf
+
+COPY cica.py cica.py
+COPY LICENSE.txt LICENSE.txt
+COPY COPYRIGHT.txt COPYRIGHT.txt
 
 ADD entrypoint.sh /usr/local/bin/entrypoint.sh
-WORKDIR /work
 
 ENTRYPOINT entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,4 @@ services:
   cica:
     build: .
     volumes:
-      - ./dist:/work/Cica/dist
+      - ./dist:/work/dist

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,19 +1,2 @@
 #!/bin/bash
-git clone https://github.com/miiton/Cica.git tmp
-cp -a tmp/.git Cica/
-cd Cica
-git checkout -- .
-curl -L https://github.com/source-foundry/Hack/releases/download/v3.003/Hack-v3.003-ttf.zip -o hack.zip
-unar hack.zip
-cp ttf/* ./sourceFonts/
-curl -LO https://osdn.jp/downloads/users/8/8598/rounded-mgenplus-20150602.7z
-unar rounded-mgenplus-20150602.7z
-cp rounded-mgenplus-20150602/rounded-mgenplus-1m-regular.ttf ./sourceFonts
-cp rounded-mgenplus-20150602/rounded-mgenplus-1m-bold.ttf ./sourceFonts
-curl -L https://github.com/googlei18n/noto-emoji/raw/master/fonts/NotoEmoji-Regular.ttf -o sourceFonts/NotoEmoji-Regular.ttf
-curl -LO http://sourceforge.net/projects/dejavu/files/dejavu/2.37/dejavu-fonts-ttf-2.37.zip
-unar dejavu-fonts-ttf-2.37.zip
-mv dejavu-fonts-ttf-2.37/ttf/DejaVuSansMono.ttf ./sourceFonts/
-mv dejavu-fonts-ttf-2.37/ttf/DejaVuSansMono-Bold.ttf ./sourceFonts/
-curl -L https://github.com/mirmat/iconsfordevs/raw/master/fonts/iconsfordevs.ttf -o sourceFonts/iconsfordevs.ttf
 fontforge -lang=py -script cica.py


### PR DESCRIPTION
docker-compose build 時に依存フォントをダウンロードし、cica.py などもコピーするようにしました。
Docker Hub 等に上げた場合、 一般利用者は pull した後、`docker run -v ./dist:/work/dist cica` でビルドだけ出来るようになります。