### PR TITLE
GitHub Actionsでビルドする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the source repository to standard location
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      # Build a container in the root of our repository and make it run
+      - name: Execute build
+        uses: ./
+
+      # Upload built results as an artifact
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: Cica-nightly-${{ github.sha }}
+          path: dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV MGENPLUS_VERSION 20150602
 ENV NOTO_EMOJI_VERSION master
 ENV DEJAVU_VERSION 2.37
 ENV ICONSFORDEVS_VERSION master
+ENV CICA_SOURCE_FONTS_PATH /work/sourceFonts
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \

--- a/cica.py
+++ b/cica.py
@@ -12,7 +12,7 @@ from datetime import datetime
 # DESCENT = 174
 ASCENT = 820
 DESCENT = 204
-SOURCE = './sourceFonts'
+SOURCE = os.getenv('CICA_SOURCE_FONTS_PATH', './sourceFonts')
 LICENSE = open('./LICENSE.txt').read()
 COPYRIGHT = open('./COPYRIGHT.txt').read()
 VERSION = '5.0.1'
@@ -91,11 +91,11 @@ def remove_glyph_from_hack(_font):
 def check_files():
     err = 0
     for f in fonts:
-        if not os.path.isfile('./sourceFonts/%s' % f.get('hack')):
+        if not os.path.isfile(os.path.join(SOURCE, f.get('hack'))):
             log('%s not exists.' % f)
             err = 1
 
-        if not os.path.isfile('./sourceFonts/%s' % f.get('mgen_plus')):
+        if not os.path.isfile(os.path.join(SOURCE, f.get('mgen_plus'))):
             log('%s not exists.' % f)
             err = 1
 
@@ -168,9 +168,9 @@ def add_dejavu(_f, conf):
     dejavu = None
     weight_name = conf.get('weight_name')
     if weight_name == "Regular":
-        dejavu = fontforge.open('./sourceFonts/DejaVuSansMono.ttf')
+        dejavu = fontforge.open(os.path.join(SOURCE, 'DejaVuSansMono.ttf'))
     elif weight_name == "Bold":
-        dejavu = fontforge.open('./sourceFonts/DejaVuSansMono-Bold.ttf')
+        dejavu = fontforge.open(os.path.join(SOURCE, 'DejaVuSansMono-Bold.ttf'))
 
     for g in dejavu.glyphs():
         g.transform(psMat.compose(psMat.scale(0.45, 0.45), psMat.translate(-21, 0)))
@@ -459,10 +459,10 @@ def modify_WM(_f):
     return _f
 
 def modify_m(_f, _weight):
-    m = fontforge.open('./sourceFonts/m-Regular.sfd')
+    m = fontforge.open(os.path.join(SOURCE, 'm-Regular.sfd'))
     if _weight == 'Bold':
         m.close()
-        m = fontforge.open('./sourceFonts/m-Bold.sfd')
+        m = fontforge.open(os.path.join(SOURCE, 'm-Bold.sfd'))
     m.selection.select(0x6d)
     m.copy()
     _f.selection.select(0x6d)
@@ -523,10 +523,10 @@ def fix_box_drawings(_f):
     return _f
 
 def reiwa(_f, _weight):
-    reiwa = fontforge.open('./sourceFonts/reiwa.sfd')
+    reiwa = fontforge.open(os.path.join(SOURCE, 'reiwa.sfd'))
     if _weight == 'Bold':
         reiwa.close()
-        reiwa = fontforge.open('./sourceFonts/reiwa-Bold.sfd')
+        reiwa = fontforge.open(os.path.join(SOURCE, 'reiwa-Bold.sfd'))
     for g in reiwa.glyphs():
         if g.isWorthOutputting:
             reiwa.selection.select(0x00)
@@ -562,7 +562,7 @@ def fix_overflow(glyph):
 def import_svg(font):
     """オリジナルのsvgグリフをインポートする
     """
-    files = glob.glob('sourceFonts/svg/*.svg')
+    files = glob.glob(os.path.join(SOURCE, 'svg/*.svg'))
     for f in files:
         filename, _ = os.path.splitext(os.path.basename(f))
         g = font.createChar(int(filename, 16))
@@ -576,12 +576,12 @@ def import_svg(font):
 
 
 def build_font(_f, emoji):
-    hack = fontforge.open('./sourceFonts/%s' % _f.get('hack'))
+    hack = fontforge.open(os.path.join(SOURCE, _f.get('hack')))
     log('remove_glyph_from_hack()')
     hack = remove_glyph_from_hack(hack)
-    cica = fontforge.open('./sourceFonts/%s' % _f.get('mgen_plus'))
-    nerd = fontforge.open('./sourceFonts/nerd.sfd')
-    icons_for_devs = fontforge.open('./sourceFonts/iconsfordevs.ttf')
+    cica = fontforge.open(os.path.join(SOURCE, _f.get('mgen_plus')))
+    nerd = fontforge.open(os.path.join(SOURCE, 'nerd.sfd'))
+    icons_for_devs = fontforge.open(os.path.join(SOURCE, 'iconsfordevs.ttf'))
 
 
     log('transform Hack')
@@ -754,7 +754,7 @@ def build_font(_f, emoji):
 
 
 def add_notoemoji(_f):
-    notoemoji = fontforge.open('./sourceFonts/NotoEmoji-Regular.ttf')
+    notoemoji = fontforge.open(os.path.join(SOURCE, 'NotoEmoji-Regular.ttf'))
     for g in notoemoji.glyphs():
         if g.isWorthOutputting and g.encoding > 0x04f9:
             g.transform((0.42,0,0,0.42,0,0))
@@ -767,7 +767,7 @@ def add_notoemoji(_f):
     return _f
 
 def add_gopher(_f):
-    gopher = fontforge.open('./sourceFonts/gopher.sfd')
+    gopher = fontforge.open(os.path.join(SOURCE, 'gopher.sfd'))
     for g in gopher.glyphs():
         if g.isWorthOutputting:
             gopher.selection.select(0x40)

--- a/cica.py
+++ b/cica.py
@@ -92,11 +92,11 @@ def check_files():
     err = 0
     for f in fonts:
         if not os.path.isfile('./sourceFonts/%s' % f.get('hack')):
-            logger.error('%s not exists.' % f)
+            log('%s not exists.' % f)
             err = 1
 
         if not os.path.isfile('./sourceFonts/%s' % f.get('mgen_plus')):
-            logger.error('%s not exists.' % f)
+            log('%s not exists.' % f)
             err = 1
 
 


### PR DESCRIPTION
Cica を GitHub Actionsでビルドする実装をしてみました。並列ビルド (#53) するにしても、まずは今のビルド処理をそのまま動かせるようにするのが第一歩でしょうし、まずはそこまで PR で貢献できたら良いなと思っています。もしよろしければ accept してください。

２点、補足です。

1. ソースフォント (`Hack-Regular.ttf` など) の置き場を指す `CICA_SOURCE_FONTS_PATH` という環境変数を導入し、これを使うように `cica.py` を変更しています
   - GitHub Actions はジョブの 1 ステップとして Dockerコンテナを実行できるので、Cica の `/Dockerfile` を実行することでビルドしています。
   - ここで、GitHub Actions は Docker コンテナを実行するときにカレントディレクトリを明示的に指定する仕様のようで (`docker run --workdir /github/workspace ...` を実行)、Dockerfile の `WORKDIR` が結果的に無視されてしまいます。その結果、`./sourceFonts` という相対パスを使っている `cica.py` はソースフォントを見つけられずエラーになります。
   - その対策として、環境変数でソースフォントを探す場所を変更できるようにしてみました
2. `cica.py` の修正内容が現在進行中の PR #52 とコンフリクトします。なので #52 を先に完了すると、この PR に修正が必要になりますが、それはこちらでやりますのでご連絡ください。

よろしくお願いします。

追伸：[GitHub Actions 実行例はこちら](https://github.com/sgryjp/Cica/actions/runs/107041817)でご確認ください。