### PR TITLE
docker-compose build で unar が失敗しないように修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,18 +13,18 @@ RUN apt-get update && \
     mkdir /work
 WORKDIR /work
 COPY sourceFonts sourceFonts
-RUN curl --fail -iL https://github.com/source-foundry/Hack/releases/download/$HACK_VERSION/Hack-$HACK_VERSION-ttf.zip -o /tmp/hack.zip && \
+RUN curl --fail -L https://github.com/source-foundry/Hack/releases/download/$HACK_VERSION/Hack-$HACK_VERSION-ttf.zip -o /tmp/hack.zip && \
     unar /tmp/hack.zip -o /tmp/hack && cp /tmp/hack/ttf/* sourceFonts/ && \
-    curl --fail -iL https://osdn.jp/downloads/users/8/8598/rounded-mgenplus-$MGENPLUS_VERSION.7z -o /tmp/rounded-mgenplus.7z && \
+    curl --fail -L https://osdn.jp/downloads/users/8/8598/rounded-mgenplus-$MGENPLUS_VERSION.7z -o /tmp/rounded-mgenplus.7z && \
     unar /tmp/rounded-mgenplus.7z -o /tmp && \
     cp /tmp/rounded-mgenplus/rounded-mgenplus-1m-regular.ttf sourceFonts/ && \
     cp /tmp/rounded-mgenplus/rounded-mgenplus-1m-bold.ttf sourceFonts/ && \
-    curl --fail -iL https://github.com/googlei18n/noto-emoji/raw/$NOTO_EMOJI_VERSION/fonts/NotoEmoji-Regular.ttf -o sourceFonts/NotoEmoji-Regular.ttf && \
-    curl --fail -iL http://sourceforge.net/projects/dejavu/files/dejavu/$DEJAVU_VERSION/dejavu-fonts-ttf-$DEJAVU_VERSION.zip -o /tmp/dejavu.zip && \
+    curl --fail -L https://github.com/googlei18n/noto-emoji/raw/$NOTO_EMOJI_VERSION/fonts/NotoEmoji-Regular.ttf -o sourceFonts/NotoEmoji-Regular.ttf && \
+    curl --fail -L http://sourceforge.net/projects/dejavu/files/dejavu/$DEJAVU_VERSION/dejavu-fonts-ttf-$DEJAVU_VERSION.zip -o /tmp/dejavu.zip && \
     unar /tmp/dejavu.zip -o /tmp && \
     cp /tmp/dejavu-fonts-ttf-$DEJAVU_VERSION/ttf/DejaVuSansMono.ttf sourceFonts/ && \
     cp /tmp/dejavu-fonts-ttf-$DEJAVU_VERSION/ttf/DejaVuSansMono-Bold.ttf sourceFonts/ && \
-    curl --fail -iL https://github.com/mirmat/iconsfordevs/raw/$ICONSFORDEVS_VERSION/fonts/iconsfordevs.ttf -o sourceFonts/iconsfordevs.ttf
+    curl --fail -L https://github.com/mirmat/iconsfordevs/raw/$ICONSFORDEVS_VERSION/fonts/iconsfordevs.ttf -o sourceFonts/iconsfordevs.ttf
 
 COPY cica.py cica.py
 COPY LICENSE.txt LICENSE.txt


### PR DESCRIPTION
## 対応内容
docker build で失敗するので修正しました.

- fix: unar が動くように DL ファイルに HTTP ヘッダを含めないように

## エラーの原因

curl の i option で HTTP ヘッダがファイルに出力されたので zip ファイルが壊れて unar で解凍できなくなっていた
```
❯ curl --fail -iL https://github.com/source-foundry/Hack/releases/download/v3.003/Hack-v3.003-ttf.zip -o example.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   625  100   625    0     0   1755      0 --:--:-- --:--:-- --:--:--  1755
100  601k  100  601k    0     0   932k      0 --:--:-- --:--:-- --:--:-- 2087k
❯ head -n 5 example.zip
HTTP/2 302
server: GitHub.com
date: Wed, 29 Sep 2021 15:36:23 GMT
content-type: text/html; charset=utf-8
vary: X-PJAX, X-PJAX-Container, Accept-Encoding, Accept, X-Requested-With
```

## 発生したエラー

```
❯ docker-compose build ; docker-compose run --rm cica
[+] Building 1.5s (9/13)
 => [internal] load build definition from Dockerfile                                                                                                                                                 0.0s
 => => transferring dockerfile: 32B                                                                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/ubuntu:18.04                                                                                                                                      0.9s
 => [internal] load build context                                                                                                                                                                    0.0s
 => => transferring context: 1.13kB                                                                                                                                                                  0.0s
 => [1/9] FROM docker.io/library/ubuntu:18.04@sha256:9bc830af2bef73276515a29aa896eedfa7bdf4bdbc5c1063b4c457a4bbb8cd79                                                                                0.0s
 => CACHED [2/9] RUN apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get -y install     software-properties-common fontforge unar git curl &&     mkdir /work                               0.0s
 => CACHED [3/9] WORKDIR /work                                                                                                                                                                       0.0s
 => CACHED [4/9] COPY sourceFonts sourceFonts                                                                                                                                                        0.0s
 => ERROR [5/9] RUN curl --fail -iL https://github.com/source-foundry/Hack/releases/download/v3.003/Hack-v3.003-ttf.zip -o /tmp/hack.zip &&     unar /tmp/hack.zip -o /tmp/hack && cp /tmp/hack/ttf  0.4s
------
 > [5/9] RUN curl --fail -iL https://github.com/source-foundry/Hack/releases/download/v3.003/Hack-v3.003-ttf.zip -o /tmp/hack.zip &&     unar /tmp/hack.zip -o /tmp/hack && cp /tmp/hack/ttf/* sourceFonts/ &&     curl --fail -iL https://osdn.jp/downloads/users/8/8598/rounded-mgenplus-20150602.7z -o /tmp/rounded-mgenplus.7z &&     unar /tmp/rounded-mgenplus.7z -o /tmp &&     cp /tmp/rounded-mgenplus/rounded-mgenplus-1m-regular.ttf sourceFonts/ &&     cp /tmp/rounded-mgenplus/rounded-mgenplus-1m-bold.ttf sourceFonts/ &&     curl --fail -iL https://github.com/googlei18n/noto-emoji/raw/main/fonts/NotoEmoji-Regular.ttf -o sourceFonts/NotoEmoji-Regular.ttf &&     curl --fail -iL http://sourceforge.net/projects/dejavu/files/dejavu/2.37/dejavu-fonts-ttf-2.37.zip -o /tmp/dejavu.zip &&     unar /tmp/dejavu.zip -o /tmp &&     cp /tmp/dejavu-fonts-ttf-2.37/ttf/DejaVuSansMono.ttf sourceFonts/ &&     cp /tmp/dejavu-fonts-ttf-2.37/ttf/DejaVuSansMono-Bold.ttf sourceFonts/ &&     curl --fail -iL https://github.com/mirmat/iconsfordevs/raw/master/fonts/iconsfordevs.ttf -o sourceFonts/iconsfordevs.ttf:
#9 0.229   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#9 0.229                                  Dload  Upload   Total   Spent    Left  Speed
100   625  100   625    0     0   9615      0 --:--:-- --:--:-- --:--:--  9615
100  601k  100  601k    0     0  4421k      0 --:--:-- --:--:-- --:--:-- 4421k
#9 0.386 /tmp/hack.zip: Zip
#9 0.390 Archive parsing failed! (Data is corrupted.)
#9 0.390 No files extracted.
------
failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c curl --fail -iL https://github.com/source-foundry/Hack/releases/download/$HACK_VERSION/Hack-$HACK_VERSION-ttf.zip -o /tmp/hack.zip &&     unar /tmp/hack.zip -o /tmp/hack && cp /tmp/hack/ttf/* sourceFonts/ &&     curl --fail -iL https://osdn.jp/downloads/users/8/8598/rounded-mgenplus-$MGENPLUS_VERSION.7z -o /tmp/rounded-mgenplus.7z &&     unar /tmp/rounded-mgenplus.7z -o /tmp &&     cp /tmp/rounded-mgenplus/rounded-mgenplus-1m-regular.ttf sourceFonts/ &&     cp /tmp/rounded-mgenplus/rounded-mgenplus-1m-bold.ttf sourceFonts/ &&     curl --fail -iL https://github.com/googlei18n/noto-emoji/raw/$NOTO_EMOJI_VERSION/fonts/NotoEmoji-Regular.ttf -o sourceFonts/NotoEmoji-Regular.ttf &&     curl --fail -iL http://sourceforge.net/projects/dejavu/files/dejavu/$DEJAVU_VERSION/dejavu-fonts-ttf-$DEJAVU_VERSION.zip -o /tmp/dejavu.zip &&     unar /tmp/dejavu.zip -o /tmp &&     cp /tmp/dejavu-fonts-ttf-$DEJAVU_VERSION/ttf/DejaVuSansMono.ttf sourceFonts/ &&     cp /tmp/dejavu-fonts-ttf-$DEJAVU_VERSION/ttf/DejaVuSansMono-Bold.ttf sourceFonts/ &&     curl --fail -iL https://github.com/mirmat/iconsfordevs/raw/$ICONSFORDEVS_VERSION/fonts/iconsfordevs.ttf -o sourceFonts/iconsfordevs.ttf]: exit code: 1
[+] Building 0.8s (9/13)
 => [internal] load build definition from Dockerfile                                                                                                                                                 0.0s
 => => transferring dockerfile: 32B                                                                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/ubuntu:18.04                                                                                                                                      0.3s
 => [internal] load build context                                                                                                                                                                    0.0s
 => => transferring context: 1.13kB                                                                                                                                                                  0.0s
 => [1/9] FROM docker.io/library/ubuntu:18.04@sha256:9bc830af2bef73276515a29aa896eedfa7bdf4bdbc5c1063b4c457a4bbb8cd79                                                                                0.0s
 => CACHED [2/9] RUN apt-get update &&     DEBIAN_FRONTEND=noninteractive apt-get -y install     software-properties-common fontforge unar git curl &&     mkdir /work                               0.0s
 => CACHED [3/9] WORKDIR /work                                                                                                                                                                       0.0s
 => CACHED [4/9] COPY sourceFonts sourceFonts                                                                                                                                                        0.0s
 => ERROR [5/9] RUN curl --fail -iL https://github.com/source-foundry/Hack/releases/download/v3.003/Hack-v3.003-ttf.zip -o /tmp/hack.zip &&     unar /tmp/hack.zip -o /tmp/hack && cp /tmp/hack/ttf  0.4s
------
 > [5/9] RUN curl --fail -iL https://github.com/source-foundry/Hack/releases/download/v3.003/Hack-v3.003-ttf.zip -o /tmp/hack.zip &&     unar /tmp/hack.zip -o /tmp/hack && cp /tmp/hack/ttf/* sourceFonts/ &&     curl --fail -iL https://osdn.jp/downloads/users/8/8598/rounded-mgenplus-20150602.7z -o /tmp/rounded-mgenplus.7z &&     unar /tmp/rounded-mgenplus.7z -o /tmp &&     cp /tmp/rounded-mgenplus/rounded-mgenplus-1m-regular.ttf sourceFonts/ &&     cp /tmp/rounded-mgenplus/rounded-mgenplus-1m-bold.ttf sourceFonts/ &&     curl --fail -iL https://github.com/googlei18n/noto-emoji/raw/main/fonts/NotoEmoji-Regular.ttf -o sourceFonts/NotoEmoji-Regular.ttf &&     curl --fail -iL http://sourceforge.net/projects/dejavu/files/dejavu/2.37/dejavu-fonts-ttf-2.37.zip -o /tmp/dejavu.zip &&     unar /tmp/dejavu.zip -o /tmp &&     cp /tmp/dejavu-fonts-ttf-2.37/ttf/DejaVuSansMono.ttf sourceFonts/ &&     cp /tmp/dejavu-fonts-ttf-2.37/ttf/DejaVuSansMono-Bold.ttf sourceFonts/ &&     curl --fail -iL https://github.com/mirmat/iconsfordevs/raw/master/fonts/iconsfordevs.ttf -o sourceFonts/iconsfordevs.ttf:
#9 0.225   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#9 0.225                                  Dload  Upload   Total   Spent    Left  Speed
100   625  100   625    0     0  13586      0 --:--:-- --:--:-- --:--:-- 13586
100  601k  100  601k    0     0  5567k      0 --:--:-- --:--:-- --:--:-- 57.0M
#9 0.356 /tmp/hack.zip: Zip
#9 0.359 Archive parsing failed! (Data is corrupted.)
#9 0.359 No files extracted.
------
failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c curl --fail -iL https://github.com/source-foundry/Hack/releases/download/$HACK_VERSION/Hack-$HACK_VERSION-ttf.zip -o /tmp/hack.zip &&     unar /tmp/hack.zip -o /tmp/hack && cp /tmp/hack/ttf/* sourceFonts/ &&     curl --fail -iL https://osdn.jp/downloads/users/8/8598/rounded-mgenplus-$MGENPLUS_VERSION.7z -o /tmp/rounded-mgenplus.7z &&     unar /tmp/rounded-mgenplus.7z -o /tmp &&     cp /tmp/rounded-mgenplus/rounded-mgenplus-1m-regular.ttf sourceFonts/ &&     cp /tmp/rounded-mgenplus/rounded-mgenplus-1m-bold.ttf sourceFonts/ &&     curl --fail -iL https://github.com/googlei18n/noto-emoji/raw/$NOTO_EMOJI_VERSION/fonts/NotoEmoji-Regular.ttf -o sourceFonts/NotoEmoji-Regular.ttf &&     curl --fail -iL http://sourceforge.net/projects/dejavu/files/dejavu/$DEJAVU_VERSION/dejavu-fonts-ttf-$DEJAVU_VERSION.zip -o /tmp/dejavu.zip &&     unar /tmp/dejavu.zip -o /tmp &&     cp /tmp/dejavu-fonts-ttf-$DEJAVU_VERSION/ttf/DejaVuSansMono.ttf sourceFonts/ &&     cp /tmp/dejavu-fonts-ttf-$DEJAVU_VERSION/ttf/DejaVuSansMono-Bold.ttf sourceFonts/ &&     curl --fail -iL https://github.com/mirmat/iconsfordevs/raw/$ICONSFORDEVS_VERSION/fonts/iconsfordevs.ttf -o sourceFonts/iconsfordevs.ttf]: exit code: 1
 ```