### PR TITLE
fix: NotoEmoji-Regular.ttfの取得元を変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:18.04
 
 ENV HACK_VERSION v3.003
 ENV MGENPLUS_VERSION 20150602
-ENV NOTO_EMOJI_VERSION main
 ENV DEJAVU_VERSION 2.37
 ENV ICONSFORDEVS_VERSION master
 ENV CICA_SOURCE_FONTS_PATH /work/sourceFonts
@@ -19,7 +18,7 @@ RUN curl --fail -L https://github.com/source-foundry/Hack/releases/download/$HAC
     unar /tmp/rounded-mgenplus.7z -o /tmp && \
     cp /tmp/rounded-mgenplus/rounded-mgenplus-1m-regular.ttf sourceFonts/ && \
     cp /tmp/rounded-mgenplus/rounded-mgenplus-1m-bold.ttf sourceFonts/ && \
-    curl --fail -L https://github.com/googlei18n/noto-emoji/raw/$NOTO_EMOJI_VERSION/fonts/NotoEmoji-Regular.ttf -o sourceFonts/NotoEmoji-Regular.ttf && \
+    curl --fail -L https://github.com/googlefonts/noto-emoji/blob/e0aa9412575fc39384efd39f90c4390d66bdd18f/fonts/NotoEmoji-Regular.ttf?raw=true -o sourceFonts/NotoEmoji-Regular.ttf && \
     curl --fail -L http://sourceforge.net/projects/dejavu/files/dejavu/$DEJAVU_VERSION/dejavu-fonts-ttf-$DEJAVU_VERSION.zip -o /tmp/dejavu.zip && \
     unar /tmp/dejavu.zip -o /tmp && \
     cp /tmp/dejavu-fonts-ttf-$DEJAVU_VERSION/ttf/DejaVuSansMono.ttf sourceFonts/ && \


### PR DESCRIPTION
## 概要
以下のcommitによってNotoEmoji-Regular.ttfが削除されており、docker-composeでエラーが発生していたので修正しました。
https://github.com/googlefonts/noto-emoji/commit/1442f6acc8463c428c8b38fc558e87c28d8efa5b


修正内容としては、とりあえず現状が動くように…という形になります。

## 対応:
- 該当箇所を削除前から取得するように修正
- Dockerfile内の使われない変数 `ENV NOTO_EMOJI_VERSION main` を削除

## 未対応:
- READMEなどその他影響箇所の修正